### PR TITLE
fix: FOverlapResult undefined error

### DIFF
--- a/Source/CollisionQueryTestActor.cpp
+++ b/Source/CollisionQueryTestActor.cpp
@@ -10,6 +10,7 @@
 #include "CollisionQueryTestActor.h"
 #include "CollisionQueryDrawDebugHelpers.h"
 #include "Engine/World.h"
+#include "Engine/OverlapResult.h"
 
 ACollisionQueryTestActor::ACollisionQueryTestActor(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)


### PR DESCRIPTION
The corresponding messages are as follows:
```
1>------ Building 4 action(s) started ------
1>[1/4] Compile [x64] CollisionQueryTestActor.cpp
1>C:\Program Files\Epic Games\UE_5.5\Engine\Source\Runtime\Core\Public\Templates\MemoryOps.h(99): error C2139: 'FOverlapResult': an undefined class is not allowed as an argument to compiler intrinsic type trait '__is_trivially_destructible'
1>C:\Program Files\Epic Games\UE_5.5\Engine\Source\Runtime\Engine\Public\WorldCollision.h(22): note: see declaration of 'FOverlapResult'
1>C:\Program Files\Epic Games\UE_5.5\Engine\Source\Runtime\Core\Public\Templates\MemoryOps.h(99): note: the template instantiation context (the oldest one first) is
1>C:\Program Files\Epic Games\UE_5.5\Engine\Source\Runtime\Engine\Public\WorldCollision.h(209): note: see reference to class template instantiation 'TArray<FOverlapResult,FDefaultAllocator>' being compiled
1>C:\Program Files\Epic Games\UE_5.5\Engine\Source\Runtime\Core\Public\Containers\Array.h(682): note: while compiling class template member function 'TArray<FOverlapResult,FDefaultAllocator>::~TArray(void)'
...
```